### PR TITLE
Fix basicAuth params

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -167,7 +167,7 @@ export async function run() {
             host: endpoint || addresses[0],
             gracefulShutdown: true,
             onConnectionError: onConnectionError,
-            lokiBasicAuth: lokiBasicAuth(),
+            basicAuth: lokiBasicAuth(),
           }),
         ],
       };


### PR DESCRIPTION
According to [winston-loki](https://www.npmjs.com/package/winston-loki/v/6.0.6) npm package, basic auth should be `basicAuth` and not `lokiBasicAuth`